### PR TITLE
Adding skip lines functionality

### DIFF
--- a/code/msaReader.cpp
+++ b/code/msaReader.cpp
@@ -19,8 +19,8 @@
 
 using namespace std;
 
-MSAReader::MSAReader(string _file, Alphabet _alphabet,  bool _checkValidation, bool _omitGaps)
-: file(_file), alphabet(_alphabet), checkValidation(_checkValidation), omitGaps(_omitGaps) {}
+MSAReader::MSAReader(string _file, Alphabet _alphabet,  bool _checkValidation, bool _omitGaps, int _skipLines)
+: file(_file), alphabet(_alphabet), checkValidation(_checkValidation), omitGaps(_omitGaps), skipLines(_skipLines) {}
 
 vector<Sequence> MSAReader::read()
 {
@@ -28,6 +28,13 @@ vector<Sequence> MSAReader::read()
     if (!inputFile)
     {
         throw runtime_error( "Failed to open the input file '"+ file + "'.");
+    }
+
+    // Skip the first n lines
+    if (skipLines > 0)
+    {
+        string line;
+        for (int i = 0; i < skipLines && std::getline(inputFile, line); ++i);
     }
 
     readFile(inputFile);

--- a/code/msaReader.h
+++ b/code/msaReader.h
@@ -23,6 +23,7 @@ protected:
     bool checkValidation;
     bool omitGaps;
     std::vector<Sequence> Sequences; // the sequences read from the file
+    int skipLines; // number of lines to skip at the beginning of the file
 
     /// @brief  Check if the MSA sequences are aligned
     /// @return -1 if aligned, otherwise return the index of the unaligned sequence     
@@ -47,7 +48,7 @@ public:
     /// @param _alphabet 
     /// @param _checkValidation 
     /// @param _omitGaps 
-    MSAReader(std::string _file, Alphabet _alphabet, bool _checkValidation, bool _omitGaps = false);
+    MSAReader(std::string _file, Alphabet _alphabet, bool _checkValidation, bool _omitGaps = false, int _skipLines = 0);
 
     /// @brief Read the MSA file
     /// @return The processed sequences in the file

--- a/code/neff.cpp
+++ b/code/neff.cpp
@@ -29,6 +29,7 @@
  *   --stoichiom=<value>               Multimer stoichiometry (default: empty)
  *   --chain_length=<list of values>   Length of the chains in heteromer multimer (default: 0)\n"
  *   --residue_neff=<true/false>       Compute per-resiue (column-wise) NEFF (default: false)
+ *   --skip_lines=<value>              Number of lines to skip at the beginning of the file (default: 0)
  *
  * For more comprehensive instructions, please refer to the documentation at https://maryam-haghani.github.io/NEFFy.
  */
@@ -131,6 +132,10 @@ Options:
   --residue_neff=<true/false>
       If true, computes per-residue (column-wise) NEFF.
       (Default: false)
+
+  --skip_lines=<value>
+      Number of lines to skip at the beginning of the input file(s).
+      (Default: 0)
 
 Examples:
   Compute the NEFF for a protein MSA:

--- a/code/neff.cpp
+++ b/code/neff.cpp
@@ -191,7 +191,8 @@ unordered_map<string, FlagInfo> Flags =
     {"multimer_MSA", {false, "false"}},     // Compute NEFF for a multimer MSA
     {"stoichiom", {false, ""}},             // Multimer stoichiometry
     {"chain_length", {false, "0"}},         // Length of the chains in heteromer multimer
-    {"residue_neff", {false, "false"}}      // Compute per-resiue (column-wise) NEFF
+    {"residue_neff", {false, "false"}},     // Compute per-resiue (column-wise) NEFF
+    {"skip_lines", {false, "0"}}            // Number of lines to skip at the beginning of the file
 };
 
 /// @brief Map char residues to digit based on given 'nonStandardOption'
@@ -777,6 +778,9 @@ int main(int argc, char **argv)
         //depth    
         depth = flagHandler.getNonZeroIntValue("depth");
 
+        // skip_lines
+        int skipLines = flagHandler.getIntValue("skip_lines");
+
         MSAReader* msaReader;
 
         for(int f=0; f<files.size(); f++)
@@ -786,19 +790,19 @@ int main(int argc, char **argv)
             string format = getFormat(file, !formats.empty()? formats[f] : "", "file");
 
             if (format == "a2m")
-                msaReader = new MSAReader_a2m(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_a2m(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
             else if(format == "a3m")
-                msaReader = new MSAReader_a3m(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_a3m(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
             else if(format == "sto")
-                msaReader = new MSAReader_sto(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_sto(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
             else if(format == "clustal")
-                msaReader = new MSAReader_clustal(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_clustal(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
             else if (format == "aln")
-                msaReader = new MSAReader_aln(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_aln(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
             else if (format == "pfam")
-                msaReader = new MSAReader_pfam(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_pfam(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
             else if (find(FASTA_FORMATS.begin(), FASTA_FORMATS.end(), format) != FASTA_FORMATS.end())
-                msaReader = new MSAReader_fasta(file, alphabet, checkValidation, omitGapsInQuery);
+                msaReader = new MSAReader_fasta(file, alphabet, checkValidation, omitGapsInQuery, skipLines);
 
             sequences = msaReader->read();
 

--- a/neffy/neffy.py
+++ b/neffy/neffy.py
@@ -196,7 +196,8 @@ def compute_neff(
         gap_cutoff: float = 1,
         pos_start: int = 1,
         pos_end: int = 'inf',
-        only_weights: bool = False
+        only_weights: bool = False,
+        skip_lines: int = 0
 ):
     try:
 
@@ -229,7 +230,8 @@ def compute_residue_neff(
         depth: int = 'inf',
         gap_cutoff: float = 1,
         pos_start: int = 1,
-        pos_end: int = 'inf'
+        pos_end: int = 'inf',
+        skip_lines: int = 0
 ):
     try:
         params = locals()
@@ -262,7 +264,8 @@ def compute_multimer_neff(
         depth: int = 'inf',
         gap_cutoff: float = 1,
         pos_start: int = 1,
-        pos_end: int = 'inf'
+        pos_end: int = 'inf',
+        skip_lines: int = 0
 ):
     try:
         params = locals()

--- a/wiki/usage_guide.md
+++ b/wiki/usage_guide.md
@@ -170,7 +170,6 @@ The code accepts the following command-line flags:
 | `--out_file=<filename>`| Specifies the output file where the converted MSA will be saved.<br /> Replace `<filename>` with the desired path and name of the output file | Yes | N/A | `--out_file=output.a2m` |
 | `--alphabet=<value>` | Alphabet of MSA <br /> __0__: Protein <br /> __1__: RNA <br /> __2__: DNA | No | 0 | `--alphabet=1` |
 | `--check_validation=[true/false]` | Validate the input MSA file based on alphabet or not | No | true | `--check_validation=true` |
-| `skip_lines` | Number of lines to skip at the beginning of the file | No | 0 | `--skip_lines=1` |
 
 Please note that the conversion is performed based on the specified input and output file extensions.
 
@@ -219,6 +218,7 @@ The method accepts the following parameters:
 | `gap_cutoff`          | float               | No       | 1 (no gappy position)        | Threshold for considering a position as gappy and removing that (between 0 and 1)   |
 | `pos_start`           | int               | No       | 1 (the first position)       | Start position of each sequence to be considered in NEFF (inclusive)                |
 | `pos_end`             | int             | No       | inf (consider the whole sequence) | Last position of each sequence to be considered in NEFF (inclusive)            |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
 
 \anchor python_neff_example
 ### Examples:
@@ -356,6 +356,7 @@ The method accepts the following parameters:
 | `gap_cutoff`          | float           | No       | 1 (no gappy position)        | Threshold for considering a position as gappy and removing that (between 0 and 1)   |
 | `pos_start`           | int             | No       | 1 (the first position)       | Start position of each sequence to be considered in NEFF (inclusive)                |
 | `pos_end`             | int             | No       | inf (consider the whole sequence) | Last position of each sequence to be considered in NEFF (inclusive)            |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
 
 \anchor python_neff_multimer_example
 ### Examples:
@@ -442,6 +443,7 @@ The method accepts the following parameters:
 | `gap_cutoff`          | float               | No       | 1 (no gappy position)        | Threshold for considering a position as gappy and removing that (between 0 and 1)   |
 | `pos_start`           | int               | No       | 1 (the first position)       | Start position of each sequence to be considered in NEFF (inclusive)                |
 | `pos_end`             | int             | No       | inf (consider the whole sequence) | Last position of each sequence to be considered in NEFF (inclusive)            |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
 
 \anchor python_neff_residue_example
 ### Examples:

--- a/wiki/usage_guide.md
+++ b/wiki/usage_guide.md
@@ -62,6 +62,7 @@ The code accepts the following command-line flags:
 | `--stoichiom=<value>` | Stochiometry of the multimer | when _multimer_MSA_=true |  | `--stoichiom=A2B1`    |
 | `--chain_length=<list of values>` | Length of the chains in a heteromer  | when _multimer_MSA_=true and multimer is a heteromer | 0 | `--chain_length=17 45`    |
 | `--residue_neff=[true/false]` | Compute per-residue (column-wise) NEFF | No | false | `--residue_neff=true`    |
+| `--skip_lines=<value>` | Number of lines to skip at the beginning of the file | No | 0 | `--skip_lines=1` |
 
 
 \anchor neff_example
@@ -169,6 +170,7 @@ The code accepts the following command-line flags:
 | `--out_file=<filename>`| Specifies the output file where the converted MSA will be saved.<br /> Replace `<filename>` with the desired path and name of the output file | Yes | N/A | `--out_file=output.a2m` |
 | `--alphabet=<value>` | Alphabet of MSA <br /> __0__: Protein <br /> __1__: RNA <br /> __2__: DNA | No | 0 | `--alphabet=1` |
 | `--check_validation=[true/false]` | Validate the input MSA file based on alphabet or not | No | true | `--check_validation=true` |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
 
 Please note that the conversion is performed based on the specified input and output file extensions.
 

--- a/wiki/usage_guide.md
+++ b/wiki/usage_guide.md
@@ -62,7 +62,7 @@ The code accepts the following command-line flags:
 | `--stoichiom=<value>` | Stochiometry of the multimer | when _multimer_MSA_=true |  | `--stoichiom=A2B1`    |
 | `--chain_length=<list of values>` | Length of the chains in a heteromer  | when _multimer_MSA_=true and multimer is a heteromer | 0 | `--chain_length=17 45`    |
 | `--residue_neff=[true/false]` | Compute per-residue (column-wise) NEFF | No | false | `--residue_neff=true`    |
-| `--skip_lines=<value>` | Number of lines to skip at the beginning of the file | No | 0 | `--skip_lines=1` |
+| `--skip_lines=<value>` | Number of lines to skip at the beginning of the input file. | No | 0 | `--skip_lines=1` |
 
 
 \anchor neff_example
@@ -218,7 +218,7 @@ The method accepts the following parameters:
 | `gap_cutoff`          | float               | No       | 1 (no gappy position)        | Threshold for considering a position as gappy and removing that (between 0 and 1)   |
 | `pos_start`           | int               | No       | 1 (the first position)       | Start position of each sequence to be considered in NEFF (inclusive)                |
 | `pos_end`             | int             | No       | inf (consider the whole sequence) | Last position of each sequence to be considered in NEFF (inclusive)            |
-| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the input file.                               |
 
 \anchor python_neff_example
 ### Examples:
@@ -356,7 +356,7 @@ The method accepts the following parameters:
 | `gap_cutoff`          | float           | No       | 1 (no gappy position)        | Threshold for considering a position as gappy and removing that (between 0 and 1)   |
 | `pos_start`           | int             | No       | 1 (the first position)       | Start position of each sequence to be considered in NEFF (inclusive)                |
 | `pos_end`             | int             | No       | inf (consider the whole sequence) | Last position of each sequence to be considered in NEFF (inclusive)            |
-| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the input file.                               |
 
 \anchor python_neff_multimer_example
 ### Examples:
@@ -443,7 +443,7 @@ The method accepts the following parameters:
 | `gap_cutoff`          | float               | No       | 1 (no gappy position)        | Threshold for considering a position as gappy and removing that (between 0 and 1)   |
 | `pos_start`           | int               | No       | 1 (the first position)       | Start position of each sequence to be considered in NEFF (inclusive)                |
 | `pos_end`             | int             | No       | inf (consider the whole sequence) | Last position of each sequence to be considered in NEFF (inclusive)            |
-| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
+| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the input file.                               |
 
 \anchor python_neff_residue_example
 ### Examples:

--- a/wiki/usage_guide.md
+++ b/wiki/usage_guide.md
@@ -170,7 +170,7 @@ The code accepts the following command-line flags:
 | `--out_file=<filename>`| Specifies the output file where the converted MSA will be saved.<br /> Replace `<filename>` with the desired path and name of the output file | Yes | N/A | `--out_file=output.a2m` |
 | `--alphabet=<value>` | Alphabet of MSA <br /> __0__: Protein <br /> __1__: RNA <br /> __2__: DNA | No | 0 | `--alphabet=1` |
 | `--check_validation=[true/false]` | Validate the input MSA file based on alphabet or not | No | true | `--check_validation=true` |
-| `skip_lines`          | int               | No       | 0                            | Number of lines to skip at the beginning of the file                               |
+| `skip_lines` | Number of lines to skip at the beginning of the file | No | 0 | --skip_lines=1 |
 
 Please note that the conversion is performed based on the specified input and output file extensions.
 

--- a/wiki/usage_guide.md
+++ b/wiki/usage_guide.md
@@ -170,7 +170,7 @@ The code accepts the following command-line flags:
 | `--out_file=<filename>`| Specifies the output file where the converted MSA will be saved.<br /> Replace `<filename>` with the desired path and name of the output file | Yes | N/A | `--out_file=output.a2m` |
 | `--alphabet=<value>` | Alphabet of MSA <br /> __0__: Protein <br /> __1__: RNA <br /> __2__: DNA | No | 0 | `--alphabet=1` |
 | `--check_validation=[true/false]` | Validate the input MSA file based on alphabet or not | No | true | `--check_validation=true` |
-| `skip_lines` | Number of lines to skip at the beginning of the file | No | 0 | --skip_lines=1 |
+| `skip_lines` | Number of lines to skip at the beginning of the file | No | 0 | `--skip_lines=1` |
 
 Please note that the conversion is performed based on the specified input and output file extensions.
 


### PR DESCRIPTION
This PR adds a new parameter to the Neff computation function that allows users to skip the first line of an input file. This is useful for certain formats of MSAs (such as those returned by ColabFold Search) and addresses **Issue #12**.

### Changes
* Added a `skip_first_line` parameter to `compute_neff`.
* Updated the relevant file-reading logic to optionally skip the first line.
* Modified the wiki files to document the new parameter and usage.

Let me know if there's anything I missed that needs changing.